### PR TITLE
Add the ability to ignore full words and regular expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ spec/examples/complete.md:24: Unordered
 
 In some cases, there may be words that are legitimately not in the dictionary you are using because they are proper nouns, or obscure technical terms.
 
-You may specify words (or even regular expresseions) to ignore via the --ignored flag:
+You may specify words (or even regular expressions) to ignore via the --ignored flag:
 
 ```
-mdspell README.md --ignored mispelled,qiute,actualy,tobe,mdspell,ruby.*,file.ame
+mdspell README.md --ignored config,mdspell,ruby.*,file.ame
 ```
 
 Likewise, you may specify this in a config file

--- a/README.md
+++ b/README.md
@@ -51,6 +51,27 @@ spec/examples/with_errors.md:5: tobe
 spec/examples/complete.md:24: Unordered
 ```
 
+### Ignore lists
+
+In some cases, there may be words that are legitimately not in the dictionary you are using because they are proper nouns, or obscure technical terms.
+
+You may specify words (or even regular expresseions) to ignore via the --ignored flag:
+
+```
+mdspell README.md --ignored mispelled,qiute,actualy,tobe,mdspell,ruby.*,file.ame
+```
+
+Likewise, you may specify this in a config file
+
+```
+ignored:
+- expr1
+- word2
+...
+```
+
+Please note that you should take care to use non-greedy, precise, regular expressions as to not mask legitimate spelling errors.
+
 ## MIT Licensed
 
 See [LICENSE](https://github.com/mtuchowski/mdspell/blob/master/LICENSE) file for full license

--- a/lib/mdspell/cli.rb
+++ b/lib/mdspell/cli.rb
@@ -17,6 +17,12 @@ module MdSpell
            long: '--language LANG',
            description: 'Set documents language'
 
+    option :ignored,
+           short: '-i IGNORED1,IGNORED2,...',
+           long: '--ignored IGNORED1,IGNORED2,...',
+           description: 'CSV of expressions to be ignored',
+           proc: Proc.new { |csv| csv.split(',') }
+
     option :verbose,
            short: '-v',
            long: '--[no-]verbose',
@@ -35,8 +41,10 @@ module MdSpell
     def run(options)
       raise ArgumentError, 'expected Array of command line options' unless options.is_a? Array
 
-      parse_options(options)
+      # Start clean
+      MdSpell::Configuration.reset
 
+      parse_options(options)
       # Load optional config file if it's present.
       if config[:config_file]
         config_filename = File.expand_path(config[:config_file])

--- a/lib/mdspell/cli.rb
+++ b/lib/mdspell/cli.rb
@@ -21,7 +21,7 @@ module MdSpell
            short: '-i IGNORED1,IGNORED2,...',
            long: '--ignored IGNORED1,IGNORED2,...',
            description: 'CSV of expressions to be ignored',
-           proc: Proc.new { |csv| csv.split(',') }
+           proc: proc { |csv| csv.split(',') }
 
     option :verbose,
            short: '-v',

--- a/lib/mdspell/configuration.rb
+++ b/lib/mdspell/configuration.rb
@@ -9,6 +9,7 @@ module MdSpell
 
     default :config_file, '~/.mdspell'
     default :language, 'en_US'
+    default :ignored, []
     default :verbose, false
     default :version, VERSION
   end

--- a/lib/mdspell/spell_checker.rb
+++ b/lib/mdspell/spell_checker.rb
@@ -29,10 +29,11 @@ module MdSpell
     # Returns found spelling errors.
     def typos
       results = []
-
+      ignored = Regexp.new(Configuration[:ignored].join('|'),  Regexp::EXTENDED | Regexp::IGNORECASE) unless Configuration[:ignored].empty?
       FFI::Aspell::Speller.open(Configuration[:language]) do |speller|
         TextLine.scan(document).each do |line|
           line.words.each do |word|
+            next if ignored =~ word
             unless speller.correct? word
               results << Typo.new(line, word, speller.suggestions(word))
             end

--- a/mdspell.gemspec
+++ b/mdspell.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
 
   # Manifest
   s.files            = Dir.glob('lib/**/*')
-  s.executables      << 'mdspell'
-  s.require_paths    = ['lib']
+  s.executables << 'mdspell'
+  s.require_paths = ['lib']
 
   s.required_ruby_version = '>= 2.0.0'
 

--- a/spec/mdspell/mdspell_spec.rb
+++ b/spec/mdspell/mdspell_spec.rb
@@ -52,7 +52,7 @@ describe MdSpell do
       end
 
       it 'should be able to ignore them' do
-        expect { subject.run [ '-i', ignored, with_errors] }.to_not raise_error
+        expect { subject.run ['-i', ignored, with_errors] }.to_not raise_error
       end
     end
   end

--- a/spec/mdspell/mdspell_spec.rb
+++ b/spec/mdspell/mdspell_spec.rb
@@ -1,6 +1,7 @@
 describe MdSpell do
   let(:simple) { 'spec/examples/simple.md' }
   let(:with_errors) { 'spec/examples/with_errors.md' }
+  let(:ignored) { 'mispelled,qiute,actualy,tobe' }
 
   it { is_expected.to respond_to :run }
 
@@ -48,6 +49,10 @@ describe MdSpell do
           allow(STDIN).to receive(:read) { 'actualy' }
           run_safely ['-']
         end.to output(/actualy/).to_stdout
+      end
+
+      it 'should be able to ignore them' do
+        expect { subject.run [ '-i', ignored, with_errors] }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
Resolves https://github.com/mtuchowski/mdspell/issues/2

This adds the ability to ignore words and regular expressions, as documented.

I did not add language specific ignores as I don't really see the value - proper nouns and technical terms are likely to span languages.
