### PR TITLE
WIP - refactor as library

### DIFF
--- a/lib/mdspell/cli.rb
+++ b/lib/mdspell/cli.rb
@@ -36,15 +36,8 @@ module MdSpell
       raise ArgumentError, 'expected Array of command line options' unless options.is_a? Array
 
       parse_options(options)
-
-      # Load optional config file if it's present.
-      if config[:config_file]
-        config_filename = File.expand_path(config[:config_file])
-        MdSpell::Configuration.from_file(config_filename) if File.exist?(config_filename)
-      end
-
-      # Store command line configuration options.
-      MdSpell::Configuration.merge!(config)
+      MdSpell::Configuration.reset
+      MdSpell::Configuration.load!(config)
     end
 
     # List of markdown files from argument list.

--- a/lib/mdspell/configuration.rb
+++ b/lib/mdspell/configuration.rb
@@ -11,5 +11,16 @@ module MdSpell
     default :language, 'en_US'
     default :verbose, false
     default :version, VERSION
+
+    def self.load!(config)
+      # Load optional config file if it's present.
+      if config[:config_file]
+        config_filename = File.expand_path(config[:config_file])
+        from_file(config_filename) if File.exist?(config_filename)
+      end
+
+      # Store command line configuration options.
+      merge!(config)
+    end
   end
 end

--- a/lib/mdspell/spell_checker.rb
+++ b/lib/mdspell/spell_checker.rb
@@ -6,23 +6,12 @@ require 'ffi/aspell'
 module MdSpell
   # A class for finding spelling errors in document.
   class SpellChecker
-    # Name of the file this object was created from.
-    attr_reader :filename
-
     # A Kramdown::Document object containing the parsed markdown document.
     attr_reader :document
 
     # Create a new instance from specified file.
-    # @param filename [String] a name of file to load.
-    def initialize(filename)
-      if filename == '-'
-        @filename = 'stdin'
-        text = STDIN.read
-      else
-        @filename = filename
-        text = File.read(filename)
-      end
-
+    # @param text [String] a name of file to load.
+    def initialize(text)
       @document = Kramdown::Document.new(text, input: 'GFM')
     end
 


### PR DESCRIPTION
@mtuchowski this is heavily WIP (tests are failing because I haven't changed any).

Intended to solve https://github.com/mtuchowski/mdspell/issues/5 

I wanted to get your thoughts on the approach here:

* I've turned mdspell into a singleton class, since that's basically what you were doing already. This makes it cleaner to hide the private methods
* I made check_file and check_string public methods. Each accepts kwargs, which are expected to be of the form that the configuration is in. 
* The kwargs are loaded in the same way that command line options are loaded, by the Configuration.load! method. 
* Spell checker no longer cares about filenames at all
* A common "spell_check" method is used, which requires a 'source', which is either a filename or a placeholder for strings (<string>)

If you are OK with this approach, I'll go through the effort of fixing the tests